### PR TITLE
Add year selection to requests

### DIFF
--- a/src/main/java/com/example/budget/domain/Request.java
+++ b/src/main/java/com/example/budget/domain/Request.java
@@ -2,6 +2,7 @@ package com.example.budget.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +18,10 @@ public class Request {
     @Column(nullable = false)
     private String name;
 
+    @NotNull
+    @Column(name = "request_year", nullable = false)
+    private Integer year;
+
     @OneToMany(mappedBy = "request", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RequestPosition> positions = new ArrayList<>();
 
@@ -30,6 +35,14 @@ public class Request {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public Integer getYear() {
+        return year;
+    }
+
+    public void setYear(Integer year) {
+        this.year = year;
     }
 
     public List<RequestPosition> getPositions() {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,10 +1,20 @@
 CREATE TABLE IF NOT EXISTS app_request_header (
     id BIGSERIAL PRIMARY KEY,
-    name VARCHAR(255) NOT NULL
+    name VARCHAR(255) NOT NULL,
+    request_year INTEGER NOT NULL
 );
 
-INSERT INTO app_request_header (name)
-SELECT 'Заявка без названия'
+ALTER TABLE app_request_header
+    ADD COLUMN IF NOT EXISTS request_year INTEGER;
+
+UPDATE app_request_header
+SET request_year = COALESCE(request_year, EXTRACT(YEAR FROM CURRENT_DATE)::INTEGER);
+
+ALTER TABLE app_request_header
+    ALTER COLUMN request_year SET NOT NULL;
+
+INSERT INTO app_request_header (name, request_year)
+SELECT 'Заявка без названия', EXTRACT(YEAR FROM CURRENT_DATE)::INTEGER
 WHERE NOT EXISTS (SELECT 1 FROM app_request_header);
 
 DO $$


### PR DESCRIPTION
## Summary
- add a mandatory `year` field to request entities and persistence schema
- expose the year column in the requests grid and card view
- extend the request form with a predefined year combo box and default value

## Testing
- `mvn -q -DskipTests compile` *(fails: unable to download parent POM because Maven Central is unreachable from the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68caad836278832988c507b49b37fba3