### PR TITLE
Make request position fields optional

### DIFF
--- a/src/main/java/com/example/budget/domain/RequestPosition.java
+++ b/src/main/java/com/example/budget/domain/RequestPosition.java
@@ -1,8 +1,6 @@
 package com.example.budget.domain;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
-
 import java.math.BigDecimal;
 import java.util.UUID;
 
@@ -44,9 +42,7 @@ public class RequestPosition {
     private Bo bo;
 
     private String vgo; // ВГО
-    @NotNull
     private BigDecimal amount; // Сумма (млн руб.)
-    @NotNull
     private BigDecimal amountNoVat; // Сумма без НДС (млн руб.)
     private String subject; // Предмет договора
     private String period; // Период (месяц)

--- a/src/main/java/com/example/budget/ui/RequestsView.java
+++ b/src/main/java/com/example/budget/ui/RequestsView.java
@@ -642,15 +642,15 @@ public class RequestsView extends VerticalLayout {
                 .setHeader("Период")
                 .setAutoWidth(true)
                 .setFlexGrow(1);
+        grid.addColumn(r -> yesNo(r.isInputObject()))
+                .setHeader("Вводный объект")
+                .setAutoWidth(true)
+                .setFlexGrow(1);
         grid.addColumn(r -> valueOrDash(r.getAmountNoVat()))
                 .setHeader("Сумма/млн. руб. (без НДС)")
                 .setAutoWidth(true)
                 .setFlexGrow(1)
                 .setTextAlign(ColumnTextAlign.END);
-        grid.addColumn(r -> yesNo(r.isInputObject()))
-                .setHeader("Вводный объект")
-                .setAutoWidth(true)
-                .setFlexGrow(1);
 
         grid.addItemClickListener(e -> openPositionCard(e.getItem()));
     }

--- a/src/main/java/com/example/budget/ui/RequestsView.java
+++ b/src/main/java/com/example/budget/ui/RequestsView.java
@@ -44,6 +44,9 @@ import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.format.DateTimeFormatter;
@@ -1290,7 +1293,16 @@ public class RequestsView extends VerticalLayout {
     }
 
     private String valueOrDash(BigDecimal value) {
-        return value != null ? value.toPlainString() : "—";
+        return value != null ? formatAmount(value) : "—";
+    }
+
+    private String formatAmount(BigDecimal value) {
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols(new Locale("ru", "RU"));
+        symbols.setGroupingSeparator(' ');
+        symbols.setDecimalSeparator(',');
+        DecimalFormat formatter = new DecimalFormat("#,##0.000", symbols);
+        formatter.setRoundingMode(RoundingMode.HALF_UP);
+        return formatter.format(value);
     }
 
     private String valueOrDash(LocalDate value) {

--- a/src/main/java/com/example/budget/ui/RequestsView.java
+++ b/src/main/java/com/example/budget/ui/RequestsView.java
@@ -623,6 +623,13 @@ public class RequestsView extends VerticalLayout {
                 .setHeader("Дата договора")
                 .setAutoWidth(true)
                 .setFlexGrow(1);
+        grid.addColumn(r -> {
+                    Contract contract = r.getContract();
+                    return contract != null ? valueOrDash(contract.getResponsible()) : "—";
+                })
+                .setHeader("Ответственный по договору (Ф.И.О.)")
+                .setAutoWidth(true)
+                .setFlexGrow(1);
         grid.addColumn(r -> valueOrDash(r.getProcurementMethod()))
                 .setHeader("Способ закупки")
                 .setAutoWidth(true)

--- a/src/main/java/com/example/budget/ui/RequestsView.java
+++ b/src/main/java/com/example/budget/ui/RequestsView.java
@@ -584,6 +584,10 @@ public class RequestsView extends VerticalLayout {
                 .setHeader("БО")
                 .setAutoWidth(true)
                 .setFlexGrow(1);
+        grid.addColumn(r -> formatZgd(r.getZgd()))
+                .setHeader("ЗГД")
+                .setAutoWidth(true)
+                .setFlexGrow(1);
         grid.addColumn(r -> valueOrDash(r.getVgo()))
                 .setHeader("ВГО")
                 .setAutoWidth(true)
@@ -1238,6 +1242,24 @@ public class RequestsView extends VerticalLayout {
             return codePart;
         }
         return namePart;
+    }
+
+    private String formatZgd(Zgd zgd) {
+        if (zgd == null) {
+            return "—";
+        }
+        String fullName = zgd.getFullName() != null ? zgd.getFullName().trim() : "";
+        String department = zgd.getDepartment() != null ? zgd.getDepartment().trim() : "";
+        if (!fullName.isEmpty() && !department.isEmpty()) {
+            return fullName + " — " + department;
+        }
+        if (!fullName.isEmpty()) {
+            return fullName;
+        }
+        if (!department.isEmpty()) {
+            return department;
+        }
+        return "—";
     }
 
     private InfoEntry entry(String label, String value) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -6,6 +6,32 @@ CREATE TABLE IF NOT EXISTS app_request_header (
 
 @@
 
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'app_request'
+          AND column_name = 'amount'
+    ) THEN
+        EXECUTE 'ALTER TABLE app_request ALTER COLUMN amount DROP NOT NULL';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'app_request'
+          AND column_name = 'amount_no_vat'
+    ) THEN
+        EXECUTE 'ALTER TABLE app_request ALTER COLUMN amount_no_vat DROP NOT NULL';
+    END IF;
+END
+$$;
+
+@@
+
 ALTER TABLE app_request_header
     ADD COLUMN IF NOT EXISTS request_year INTEGER;
 


### PR DESCRIPTION
## Summary
- allow request positions to be saved without amount values by dropping bean-validation requirements
- relax the database schema so the amount fields accept NULL values

## Testing
- mvn -q -DskipTests package *(fails: cannot download parent POM in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1ed5fbcc8329be3be7908351ed10