### PR TITLE
Update request Excel export header rows

### DIFF
--- a/src/main/java/com/example/budget/service/RequestExcelExportService.java
+++ b/src/main/java/com/example/budget/service/RequestExcelExportService.java
@@ -2,6 +2,7 @@ package com.example.budget.service;
 
 import com.example.budget.domain.Bdz;
 import com.example.budget.domain.Bo;
+import com.example.budget.domain.Cfo;
 import com.example.budget.domain.CfoTwo;
 import com.example.budget.domain.Contract;
 import com.example.budget.domain.Counterparty;
@@ -52,9 +53,18 @@ public class RequestExcelExportService {
             Sheet sheet = workbook.createSheet("Заявка");
             int rowIndex = 0;
 
+            Row cfoRow = sheet.createRow(rowIndex++);
+            setStringCell(cfoRow, 0, formatCodeAndName(request.getCfo()));
+
             Row requestInfoRow = sheet.createRow(rowIndex++);
-            setStringCell(requestInfoRow, 0, safeString(request.getName()));
-            setStringCell(requestInfoRow, 1, request.getYear() != null ? request.getYear().toString() : "");
+            String requestName = safeString(request.getName());
+            Integer requestYear = request.getYear();
+            String yearValue = requestYear != null ? requestYear.toString() : "";
+            String requestInfo = requestName;
+            if (hasText(yearValue)) {
+                requestInfo = hasText(requestName) ? requestName + " " + yearValue : yearValue;
+            }
+            setStringCell(requestInfoRow, 0, requestInfo);
 
             String[] headers = {
                     "№",
@@ -150,6 +160,13 @@ public class RequestExcelExportService {
             return "";
         }
         return formatCodeAndName(cfoTwo.getCode(), cfoTwo.getName());
+    }
+
+    private String formatCodeAndName(Cfo cfo) {
+        if (cfo == null) {
+            return "";
+        }
+        return formatCodeAndName(cfo.getCode(), cfo.getName());
     }
 
     private String formatCodeAndName(Mvz mvz) {

--- a/src/main/java/com/example/budget/service/RequestExcelExportService.java
+++ b/src/main/java/com/example/budget/service/RequestExcelExportService.java
@@ -5,6 +5,7 @@ import com.example.budget.domain.Bo;
 import com.example.budget.domain.Cfo;
 import com.example.budget.domain.CfoTwo;
 import com.example.budget.domain.Contract;
+import com.example.budget.domain.ContractAmount;
 import com.example.budget.domain.Counterparty;
 import com.example.budget.domain.Mvz;
 import com.example.budget.domain.Request;
@@ -112,7 +113,7 @@ public class RequestExcelExportService {
                 setStringCell(row, 11, safeString(position.getSubject()), dataStyle);
                 setStringCell(row, 12, safeString(position.getPeriod()), dataStyle);
                 setAmountCell(row, 13, position.getAmountNoVat(), numericAmountStyle);
-                setAmountCell(row, 14, position.isInputObject() ? position.getAmount() : null, numericAmountStyle);
+                setAmountCell(row, 14, resolveInputObjectAmount(position), numericAmountStyle);
             }
 
             for (int i = 0; i < headers.length; i++) {
@@ -188,6 +189,17 @@ public class RequestExcelExportService {
 
     private void mergeCells(Sheet sheet, int rowIndex, int firstColumn, int lastColumn) {
         sheet.addMergedRegion(new CellRangeAddress(rowIndex, rowIndex, firstColumn, lastColumn));
+    }
+
+    private BigDecimal resolveInputObjectAmount(RequestPosition position) {
+        if (position == null || !position.isInputObject()) {
+            return null;
+        }
+        ContractAmount contractAmount = position.getContractAmount();
+        if (contractAmount != null && contractAmount.getAmount() != null) {
+            return contractAmount.getAmount();
+        }
+        return position.getAmount();
     }
 
     private String formatCodeAndName(Bdz bdz) {


### PR DESCRIPTION
## Summary
- add the CFO I code and name as the first row when exporting a request to Excel
- move the request name and year into a combined second row value in the export
- provide a helper to format CFO values for the spreadsheet output

## Testing
- `mvn -q test` *(fails: dependency download requires external network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5f692f00832993cb69db681a7a6c