### PR TITLE
Adjust request export header rows

### DIFF
--- a/src/main/java/com/example/budget/service/RequestExcelExportService.java
+++ b/src/main/java/com/example/budget/service/RequestExcelExportService.java
@@ -84,8 +84,9 @@ public class RequestExcelExportService {
                     "Ответственный по договору (Ф.И.О.)",
                     "Предмет договора",
                     "Период",
-                    "Сумма/млн. руб. (без НДС)",
-                    "Затраты связанные с вводными объектами, в млн.руб. (без НДС)"
+                    "Сумма по БДЗ (без НДС/млн. руб.)",
+                    "Затраты связанные с вводными объектами, в млн.руб. (без НДС)",
+                    "Сумма по договору (без НДС/млн. руб.)"
             };
 
             CellStyle headerStyle = createHeaderStyle(workbook);
@@ -116,6 +117,7 @@ public class RequestExcelExportService {
                 setStringCell(row, 12, safeString(position.getPeriod()), dataStyle);
                 setAmountCell(row, 13, position.getAmountNoVat(), numericAmountStyle);
                 setAmountCell(row, 14, resolveInputObjectAmount(position), numericAmountStyle);
+                setAmountCell(row, 15, resolveContractAmount(position), numericAmountStyle);
             }
 
             for (int i = 0; i < headers.length; i++) {
@@ -210,14 +212,21 @@ public class RequestExcelExportService {
     }
 
     private BigDecimal resolveInputObjectAmount(RequestPosition position) {
-        if (position == null || !position.isInputObject()) {
+        if (position == null) {
+            return null;
+        }
+        if (!position.isInputObject()) {
+            return BigDecimal.ZERO;
+        }
+        return position.getAmountNoVat();
+    }
+
+    private BigDecimal resolveContractAmount(RequestPosition position) {
+        if (position == null) {
             return null;
         }
         ContractAmount contractAmount = position.getContractAmount();
-        if (contractAmount != null && contractAmount.getAmount() != null) {
-            return contractAmount.getAmount();
-        }
-        return position.getAmount();
+        return contractAmount != null ? contractAmount.getAmount() : null;
     }
 
     private String formatCodeAndName(Bdz bdz) {

--- a/src/main/java/com/example/budget/service/RequestExcelExportService.java
+++ b/src/main/java/com/example/budget/service/RequestExcelExportService.java
@@ -57,16 +57,18 @@ public class RequestExcelExportService {
             Sheet sheet = workbook.createSheet("Заявка");
             int rowIndex = 0;
 
+            CellStyle titleStyle = createTitleStyle(workbook);
+
             Row cfoRow = sheet.createRow(rowIndex++);
             Cfo cfo = request.getCfo();
             String cfoCode = cfo != null ? safeTrim(cfo.getCode()) : "";
             String cfoName = cfo != null ? safeTrim(cfo.getName()) : "";
-            fillMergedRow(sheet, cfoRow, 0, cfoCode, cfoName);
+            fillTitleRow(sheet, cfoRow, "ЦФО I", cfoCode, cfoName, titleStyle);
 
             Row requestInfoRow = sheet.createRow(rowIndex++);
             String requestName = safeTrim(request.getName());
             String yearValue = safeTrim(request.getYear() != null ? request.getYear().toString() : null);
-            fillMergedRow(sheet, requestInfoRow, 0, requestName, yearValue);
+            fillTitleRow(sheet, requestInfoRow, "Заявка", yearValue, requestName, titleStyle);
 
             String[] headers = {
                     "№",
@@ -136,6 +138,15 @@ public class RequestExcelExportService {
         return style;
     }
 
+    private CellStyle createTitleStyle(Workbook workbook) {
+        Font font = workbook.createFont();
+        font.setBold(true);
+        font.setFontHeightInPoints((short) 14);
+        CellStyle style = workbook.createCellStyle();
+        style.setFont(font);
+        return style;
+    }
+
     private CellStyle createDataStyle(Workbook workbook) {
         CellStyle style = workbook.createCellStyle();
         applyAllBorders(style);
@@ -179,12 +190,19 @@ public class RequestExcelExportService {
         }
     }
 
-    private void fillMergedRow(Sheet sheet, Row row, int firstColumn, String firstValue, String secondValue) {
-        Cell firstCell = row.createCell(firstColumn);
-        firstCell.setCellValue(firstValue);
-        row.createCell(firstColumn + 1).setCellValue(secondValue);
-        mergeCells(sheet, row.getRowNum(), firstColumn, firstColumn + 1);
-        firstCell.setCellValue(joinWithSpace(firstValue, secondValue));
+    private void fillTitleRow(Sheet sheet, Row row, String label, String middleValue, String mergedValue, CellStyle style) {
+        if (style != null) {
+            row.setHeightInPoints(20f);
+        }
+        setStringCell(row, 0, label, style);
+        setStringCell(row, 1, "", style);
+        mergeCells(sheet, row.getRowNum(), 0, 1);
+
+        setStringCell(row, 2, middleValue, style);
+
+        setStringCell(row, 3, mergedValue, style);
+        setStringCell(row, 4, "", style);
+        mergeCells(sheet, row.getRowNum(), 3, 4);
     }
 
     private void mergeCells(Sheet sheet, int rowIndex, int firstColumn, int lastColumn) {


### PR DESCRIPTION
## Summary
- restructure the first two rows of the export to display labelled CFO and request information using the requested merged cells
- add a dedicated bold, enlarged title style for those rows and adjust the workbook builder to use it

## Testing
- mvn -q test *(fails: unable to resolve parent POM because Maven Central is unreachable from the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd32158a988329a7f268bf68459883